### PR TITLE
Changed the TotalPosts value

### DIFF
--- a/commands/instagram.js
+++ b/commands/instagram.js
@@ -38,7 +38,7 @@ module.exports = {
         .setColor('RANDOM')
         .setThumbnail(insta.pic)
         .addFields(
-          {name: 'TotalPosts', value: insta.post, inline:true},
+          {name: 'TotalPosts', value: insta.posts, inline:true},
           {name:'Followers', value: insta.followers, inline:true},
           {name: 'Followings', value:insta.following, inline:true}
         )


### PR DESCRIPTION
changed the value from `insta.post`  to `insta.posts` in order to match the [`scraper-instagram` ](https://git.kaki87.net/KaKi87/ig-scraper)module's documentation.